### PR TITLE
Fix CentOS 7 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ RPMS are created in folder `/tmp/tito` including `/tmp/tito/x86_64`.
 
 Always validate spec file with:
 ```bash
+# for CentOS 7
 rpmlint -i cmake-demo.spec
+# for Fedora 35
+rpmlint -v cmake-demo.spec
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For CentOS 7:
 - EPEL required
 
 ```bash
-sudo yum install cmake3 make gcc
+sudo yum install cmake3 cmake3-data make gcc
 ```
 
 And build under `~/tmp`:
@@ -44,6 +44,13 @@ tito build --rpm
 
 RPMS are created in folder `/tmp/tito` including `/tmp/tito/x86_64`.
 
+
+# NOTES
+
+Always validate spec file with:
+```bash
+rpmlint -i cmake-demo.spec
+```
 
 
 

--- a/cmake-demo.spec
+++ b/cmake-demo.spec
@@ -4,7 +4,7 @@ Version:        0.0.0
 Release:        1
 Summary:        cmake demo to test library and binary paths
 
-Group:          Development Tools
+Group:          Development/Tools
 License:        MIT
 URL:            https://github.com/hpaluch-pil/clockres
 # NOTE: Must have .tar.gz suffix to work properly with Tito builder
@@ -12,9 +12,12 @@ Source0:        %{name}-%{version}.tar.gz
 #BuildArch:      x86_64
 
 BuildRequires:  gcc make
-BuildRequires:  cmake >= 3.0
+%if %{defined cmake3}
 # on CentOS7 we have to use:
-#BuildRequires:  cmake3 cmake3-data
+BuildRequires:  cmake3 cmake3-data
+%else
+BuildRequires:  cmake >= 3.0
+%endif
 %description
 Trivial demo app and library to test cmake integration
 with RPM tools
@@ -23,12 +26,23 @@ with RPM tools
 %setup -q 
 
 %build
+%if %{defined cmake3}
+# on CentOS7 we have to use:
+%cmake3
+%cmake3_build
+%else
 %cmake
 %cmake_build
+%endif
 
 %install
 
+%if %{defined cmake3}
+# on CentOS7 we have to use:
+%cmake3_install
+%else
 %cmake_install
+%endif
 
 %files
 %license LICENSE

--- a/cmake-demo.spec
+++ b/cmake-demo.spec
@@ -12,7 +12,9 @@ Source0:        %{name}-%{version}.tar.gz
 #BuildArch:      x86_64
 
 BuildRequires:  gcc make
-%if %{defined cmake3}
+# NOTE: We can't test if 'cmake3' because it is defined even in Fedora 35!!
+#       However '__cmake3' is defined under CentOS 7 only
+%if %{defined __cmake3}
 # on CentOS7 we have to use:
 BuildRequires:  cmake3 cmake3-data
 %else
@@ -26,7 +28,7 @@ with RPM tools
 %setup -q 
 
 %build
-%if %{defined cmake3}
+%if %{defined __cmake3}
 # on CentOS7 we have to use:
 %cmake3
 %cmake3_build
@@ -37,7 +39,7 @@ with RPM tools
 
 %install
 
-%if %{defined cmake3}
+%if %{defined __cmake3}
 # on CentOS7 we have to use:
 %cmake3_install
 %else


### PR DESCRIPTION
Fix building under CentOS which uses cmake3 packages (instead of cmake package) and different macros (with cmake3 suffix)